### PR TITLE
Add the buildkite-pipeline to the catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-github-stats-crawler
+spec:
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      description: GitHub issues crawler.
+      name: GitHub Stats Crawler
+    spec:
+      repository: elastic/issue-crawler
+      teams:
+        ci-systems: {}
+  owner: group:ci-systems
+  type: buildkite-pipeline

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:


### PR DESCRIPTION
Terrazzo currently uses the data defined in https://github.com/elastic/ci/blob/main/terrazzo/manifests/prod/buildkite/ to define the BK pipeline. Moving forward, teams should store this information in the affected repo so this PR converts the existing data into an RRE and stores it here.