### PR TITLE
the crawler doesn't cleanup removed issues from index

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,14 +198,14 @@ async function cleanupTransferredIssues(owner, repo, isPrivate = false) {
         try {
             await octokit.issues.get({ owner, repo, issue_number: issueNumber });
         } catch (err) {
-            if (err.status === 301) {
+            if ([301, 404, 410].includes(err.status)) {
                 stillExists = false;
             } else {
                 console.error(`[CLEANUP] Error verifying #${issueNumber}:`, err);
             }
         }
         if (!stillExists) {
-            console.log(`[CLEANUP] Issue #${issueNumber} was moved; deleting from Elasticsearch`);
+            console.log(`[CLEANUP] Issue #${issueNumber} was removed (status ${err && err.status}); deleting from Elasticsearch`);
             await client.delete({
                 index: indexName,
                 id: docId


### PR DESCRIPTION
I've slightly expanded the scope of [GH Issues that get moved to a different repo are not filterable](https://elasticco.atlassian.net/browse/O11Y-1314) as I noticed that the crawler goes over the same deleted issues:
[deleted issue](https://buildkite.com/elastic/github-stats-crawler/builds/13641#01975c4a-0b6d-43ec-a3d1-04d3d166fe32/58-261) is [marked as existing](https://buildkite.com/elastic/github-stats-crawler/builds/13641#01975c4a-0b6d-43ec-a3d1-04d3d166fe32/58-267) here