### PR TITLE
Migration: reassign team ownership to @elastic/builder-experience

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,6 +13,6 @@ spec:
     spec:
       repository: elastic/issue-crawler
       teams:
-        ci-systems: {}
+        builder-experience: {}
   owner: group:builder-experience
   type: buildkite-pipeline

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -14,5 +14,5 @@ spec:
       repository: elastic/issue-crawler
       teams:
         ci-systems: {}
-  owner: group:productivity-foundations
+  owner: group:builder-experience
   type: buildkite-pipeline


### PR DESCRIPTION
Part of the EngProd GitHub team migration (parent: [#2148](https://github.com/elastic/platform-engineering-productivity/issues/2148), this touchpoint: [#2426](https://github.com/elastic/platform-engineering-productivity/issues/2426)).

**⚠️ DO NOT MERGE** until migration day. PRs are merged in batches grouped by new team owner so the [Terrazzo](https://github.com/elastic/terrazzo) wild plan for each batch can be reviewed and approved independently.


### Files changed

- `catalog-info.yaml` (1 line)

---

Generated by `scripts/github-team-migration/open_repo_prs.py`.